### PR TITLE
feat: add luxury noir chat panel with responsive designFeature/chat with ai

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -198,17 +198,19 @@
 
 /* ===== Table ===== */
 .table-area {
-  flex: 1;
+  grid-area: table;
   position: relative;
+  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 12px var(--table-side-padding, 10px) 14px 16px;
+  min-height: 0;
+  padding: 10px 8px 6px;
 }
 
 .poker-table {
-  width: min(92vw, calc(100vw - var(--table-side-padding, 10px) - 24px), 820px);
-  height: min(55vh, 420px);
+  width: min(100%, 860px);
+  height: clamp(300px, 54vh, 440px);
   background:
     radial-gradient(ellipse at 40% 35%, rgba(255, 255, 255, 0.06) 0%, transparent 50%),
     radial-gradient(ellipse at center, var(--green-felt-light) 0%, var(--green-felt) 60%, var(--green-felt-dark) 100%);
@@ -484,8 +486,11 @@
 .my-hand-area {
   display: flex;
   justify-content: center;
-  gap: 12px;
-  padding: 8px 0 4px;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 96px;
+  padding: 2px 0 0;
 }
 
 .my-hand-area .card {
@@ -512,46 +517,67 @@
 
 /* ===== Bottom Controls ===== */
 .bottom-controls {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  z-index: 100;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-end;
-  gap: 12px;
-  padding: 12px 20px;
-  pointer-events: none;
-}
-
-.bottom-controls > * {
-  pointer-events: auto;
-}
-
-.my-hand-area {
-  flex: 1;
+  grid-area: controls;
+  position: relative;
+  z-index: 130;
   display: flex;
   justify-content: center;
+  align-items: flex-end;
+  padding: 2px 6px max(10px, env(safe-area-inset-bottom));
+}
+
+.action-center {
+  position: relative;
+  z-index: 130;
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  margin-bottom: 8px;
+  gap: 8px;
+  padding: 8px 12px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(7, 12, 21, 0.75), rgba(7, 12, 21, 0.92));
+  box-shadow: 0 -8px 26px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(18px);
+}
+
+.timer-cluster {
+  width: min(560px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 /* ===== Action Bar ===== */
 .action-bar {
-  padding: 12px 20px;
+  width: 100%;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(10, 14, 23, 0.74) 0%, rgba(10, 14, 23, 0.9) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.action-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  background: linear-gradient(180deg, rgba(10, 14, 23, 0.92) 0%, rgba(10, 14, 23, 0.98) 100%);
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(16px);
+}
+
+.action-row-main {
+  justify-content: center;
   flex-wrap: wrap;
+  gap: 10px;
+}
+
+.action-row-raise {
   justify-content: center;
   width: 100%;
-  position: relative;
-  z-index: 100;
 }
 
 .action-bar button {
@@ -698,15 +724,20 @@
 .raise-controls {
   display: flex;
   align-items: center;
-  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: min(620px, 100%);
   background: rgba(255, 255, 255, 0.04);
-  padding: 6px 14px;
+  padding: 8px 10px;
   border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .raise-controls input[type="range"] {
-  width: 120px;
+  flex: 1 1 140px;
+  min-width: 120px;
+  max-width: 220px;
   height: 4px;
   accent-color: var(--accent);
   padding: 0;
@@ -744,8 +775,8 @@
 
 /* ===== Timer ===== */
 .timer-bar {
-  width: min(95vw, 800px);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   height: 5px;
   background: rgba(255, 255, 255, 0.06);
   position: relative;
@@ -772,8 +803,8 @@
   font-size: 15px;
   font-weight: 700;
   color: var(--gold);
-  height: 22px;
-  margin: 4px 0;
+  min-height: 22px;
+  margin: 0;
   text-shadow: 0 0 12px var(--gold-glow);
   letter-spacing: 0.5px;
 }
@@ -996,48 +1027,39 @@
 
 /* ===== Game View ===== */
 #game-view {
-  --comms-dock-width: clamp(270px, 21vw, 330px);
-  --comms-dock-bottom: 124px;
-  --table-side-padding: calc(var(--comms-dock-width) + 34px);
+  --comms-dock-width: clamp(270px, 23vw, 340px);
   flex: 1;
   min-height: 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--comms-dock-width);
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-areas:
+    "status status"
+    "table comms"
+    "controls comms";
+  column-gap: 12px;
+  row-gap: 8px;
   position: relative;
+  padding: 0 10px 6px;
+}
+
+#game-view > .status-message {
+  grid-area: status;
+  margin: 0 -10px;
 }
 
 /* ===== Comms Dock ===== */
 .comms-dock {
-  position: absolute;
-  right: max(12px, env(safe-area-inset-right));
-  bottom: var(--comms-dock-bottom);
-  width: var(--comms-dock-width);
+  grid-area: comms;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  z-index: 125;
-  pointer-events: none;
-}
-
-.comms-dock > * {
-  pointer-events: auto;
-}
-
-.comms-toggle {
-  display: none;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
   width: 100%;
-  padding: 8px 12px;
-  border-radius: 11px;
-  border: 1px solid rgba(240, 192, 64, 0.36);
-  background: linear-gradient(165deg, rgba(240, 192, 64, 0.2), rgba(240, 192, 64, 0.08));
-  color: #f3ead4;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.4px;
-  backdrop-filter: blur(10px);
+  min-height: 0;
+  align-self: stretch;
+  min-width: 0;
+  max-width: 100%;
+  z-index: 140;
 }
 
 .chat-container,
@@ -1093,7 +1115,8 @@
 
 /* ===== Chat ===== */
 .chat-container {
-  height: min(320px, 38vh);
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -1260,7 +1283,8 @@
 
 /* ===== Game Log ===== */
 .game-log-panel {
-  height: min(160px, 20vh);
+  flex: 0 0 clamp(122px, 21vh, 182px);
+  min-height: 108px;
   display: flex;
   flex-direction: column;
 }
@@ -1374,28 +1398,29 @@
 }
 
 /* Responsive layout for table + comms */
-@media (max-width: 1680px) {
+@media (max-width: 1440px) {
   #game-view {
-    --comms-dock-width: clamp(250px, 20vw, 300px);
-    --table-side-padding: calc(var(--comms-dock-width) + 28px);
+    --comms-dock-width: clamp(248px, 24vw, 300px);
   }
 
   .poker-table {
-    width: min(90vw, calc(100vw - var(--table-side-padding) - 20px), 790px);
-    height: min(53vh, 400px);
+    height: clamp(280px, 50vh, 400px);
+  }
+
+  .my-hand-area .card {
+    width: 72px;
+    height: 100px;
   }
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1240px) {
   #game-view {
-    --comms-dock-width: 270px;
-    --comms-dock-bottom: 118px;
-    --table-side-padding: 292px;
+    --comms-dock-width: clamp(228px, 28vw, 276px);
+    column-gap: 10px;
   }
 
   .poker-table {
-    width: min(88vw, calc(100vw - var(--table-side-padding) - 18px), 740px);
-    height: min(49vh, 370px);
+    height: clamp(260px, 47vh, 360px);
   }
 
   .player-info {
@@ -1411,120 +1436,123 @@
   .player-chips {
     font-size: 14px;
   }
-}
 
-@media (max-width: 1100px) {
-  #game-view {
-    --table-side-padding: 16px;
-    --comms-dock-width: min(520px, calc(100vw - 20px));
-    --comms-dock-bottom: 110px;
-  }
-
-  .table-area {
-    padding: 8px 12px 148px;
-  }
-
-  .comms-dock {
-    left: 10px;
-    right: 10px;
-    width: auto;
-    display: grid;
-    grid-template-columns: 1.4fr 1fr;
-    gap: 8px;
-  }
-
-  .chat-container {
-    min-width: 0;
-    height: min(220px, 30vh);
-  }
-
-  .game-log-panel {
-    min-width: 0;
-    height: min(156px, 20vh);
+  .action-bar button {
+    min-width: 84px;
+    padding: 9px 16px;
   }
 }
 
-@media (max-width: 920px), (max-height: 820px) {
+@media (max-width: 980px), (max-height: 780px) {
   #game-view {
-    --table-side-padding: 14px;
-    --comms-dock-bottom: 104px;
+    --comms-dock-width: clamp(148px, 33vw, 212px);
+    grid-template-columns: minmax(0, 1fr) var(--comms-dock-width);
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "status status"
+      "table comms"
+      "controls comms";
+    column-gap: 8px;
+    row-gap: 8px;
+    padding: 0 6px 8px;
+  }
+
+  #game-view > .status-message {
+    margin: 0 -6px;
   }
 
   .table-area {
-    padding: 8px 10px 134px;
+    padding: 6px 2px 4px;
   }
 
   .poker-table {
-    width: min(94vw, 640px);
-    height: min(43vh, 320px);
+    width: min(100%, 620px);
+    height: clamp(208px, 38vh, 296px);
     border-width: 4px;
     outline-width: 3px;
   }
 
   .comms-dock {
-    left: 10px;
-    right: 10px;
-    width: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+    gap: 6px;
+    width: 100%;
+    min-width: 0;
+    justify-self: stretch;
   }
 
-  .comms-dock.is-compact .comms-toggle {
-    display: flex;
-  }
-
-  .comms-dock.is-collapsed .chat-container,
-  .comms-dock.is-collapsed .game-log-panel {
-    display: none;
-  }
-
-  .comms-dock.is-collapsed {
-    left: auto;
-    right: 10px;
-    width: min(220px, calc(100vw - 20px));
+  .chat-container,
+  .game-log-panel {
+    border-color: rgba(240, 192, 64, 0.28);
+    background: linear-gradient(165deg, rgba(8, 14, 23, 0.74), rgba(8, 14, 23, 0.88));
+    backdrop-filter: blur(12px);
   }
 
   .chat-container {
-    height: min(190px, 27vh);
+    flex: 1 1 auto;
+    min-height: 140px;
   }
 
   .game-log-panel {
-    height: min(120px, 16vh);
+    flex: 0 0 clamp(82px, 16vh, 120px);
+    min-height: 72px;
   }
 
   .chat-text {
     font-size: 12.5px;
   }
 
-  .bottom-controls {
-    gap: 8px;
-    padding: 8px 12px;
+  .action-center {
+    border-radius: 14px;
+    padding: 8px 10px 9px;
+    background: linear-gradient(180deg, rgba(7, 12, 21, 0.66), rgba(7, 12, 21, 0.88));
   }
 
   .action-bar {
+    padding: 8px 10px;
     gap: 8px;
-    padding: 10px 12px;
+  }
+
+  .action-row-main {
+    gap: 8px;
+  }
+
+  .action-bar button {
+    min-width: 78px;
+    padding: 9px 14px;
+  }
+
+  .my-hand-area {
+    min-height: 82px;
+    gap: 8px;
   }
 
   .my-hand-area .card {
-    width: 68px;
-    height: 95px;
+    width: 64px;
+    height: 90px;
+  }
+
+  .my-hand-area .card .card-rank {
+    font-size: 22px;
+  }
+
+  .my-hand-area .card .card-suit {
+    font-size: 24px;
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 680px) {
   #game-view {
-    --comms-dock-bottom: 98px;
+    --comms-dock-width: clamp(126px, 40vw, 168px);
+    column-gap: 6px;
+    padding: 0 4px 6px;
   }
 
-  .table-area {
-    padding: 8px 8px 126px;
+  #game-view > .status-message {
+    margin: 0 -4px;
   }
 
   .poker-table {
-    width: min(95vw, 520px);
-    height: min(38vh, 270px);
+    width: min(100%, 460px);
+    height: clamp(184px, 33vh, 244px);
   }
 
   .player-info {
@@ -1546,30 +1574,12 @@
     padding: 2px 5px;
   }
 
-  .comms-dock.is-collapsed {
-    right: 8px;
-    width: min(200px, calc(100vw - 16px));
-  }
-
-  .comms-toggle {
-    padding: 7px 10px;
-    font-size: 11px;
-  }
-
   .comms-header {
     padding: 8px 10px 7px;
   }
 
   .comms-title {
     font-size: 15px;
-  }
-
-  .chat-container {
-    height: min(162px, 24vh);
-  }
-
-  .game-log-panel {
-    height: min(94px, 14vh);
   }
 
   .chat-input-area {
@@ -1588,8 +1598,52 @@
     font-size: 11px;
   }
 
+  .raise-controls {
+    padding: 7px 8px;
+  }
+
+  .raise-controls input[type="range"] {
+    flex-basis: 112px;
+    min-width: 104px;
+  }
+
+  .raise-input {
+    width: 64px;
+    padding: 5px 6px;
+    font-size: 13px;
+  }
+
+  .action-bar button {
+    min-width: 72px;
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+
   .my-hand-area .card {
-    width: 60px;
-    height: 84px;
+    width: 56px;
+    height: 80px;
+  }
+}
+
+@media (max-height: 700px) {
+  .poker-table {
+    height: clamp(210px, 36vh, 280px);
+  }
+
+  .my-hand-area {
+    min-height: 72px;
+  }
+
+  .my-hand-area .card {
+    width: 52px;
+    height: 74px;
+  }
+
+  .chat-container {
+    flex-basis: min(26vh, 200px);
+  }
+
+  .game-log-panel {
+    flex-basis: min(15vh, 108px);
   }
 }

--- a/public/css/game.css
+++ b/public/css/game.css
@@ -203,11 +203,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px;
+  padding: 12px var(--table-side-padding, 10px) 14px 16px;
 }
 
 .poker-table {
-  width: min(95vw, 800px);
+  width: min(92vw, calc(100vw - var(--table-side-padding, 10px) - 24px), 820px);
   height: min(55vh, 420px);
   background:
     radial-gradient(ellipse at 40% 35%, rgba(255, 255, 255, 0.06) 0%, transparent 50%),
@@ -996,6 +996,9 @@
 
 /* ===== Game View ===== */
 #game-view {
+  --comms-dock-width: clamp(270px, 21vw, 330px);
+  --comms-dock-bottom: 124px;
+  --table-side-padding: calc(var(--comms-dock-width) + 34px);
   flex: 1;
   min-height: 0;
   display: flex;
@@ -1006,12 +1009,12 @@
 /* ===== Comms Dock ===== */
 .comms-dock {
   position: absolute;
-  right: 20px;
-  bottom: 124px;
-  width: min(360px, calc(100vw - 32px));
+  right: max(12px, env(safe-area-inset-right));
+  bottom: var(--comms-dock-bottom);
+  width: var(--comms-dock-width);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
   z-index: 125;
   pointer-events: none;
 }
@@ -1020,9 +1023,26 @@
   pointer-events: auto;
 }
 
+.comms-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 11px;
+  border: 1px solid rgba(240, 192, 64, 0.36);
+  background: linear-gradient(165deg, rgba(240, 192, 64, 0.2), rgba(240, 192, 64, 0.08));
+  color: #f3ead4;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  backdrop-filter: blur(10px);
+}
+
 .chat-container,
 .game-log-panel {
-  border-radius: 16px;
+  border-radius: 14px;
   border: 1px solid rgba(240, 192, 64, 0.22);
   background: linear-gradient(165deg, rgba(14, 21, 33, 0.92) 0%, rgba(7, 11, 19, 0.96) 100%);
   box-shadow:
@@ -1046,7 +1066,7 @@
 }
 
 .comms-header {
-  padding: 10px 14px 9px;
+  padding: 9px 12px 8px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   background: linear-gradient(180deg, rgba(240, 192, 64, 0.14), rgba(240, 192, 64, 0.02));
 }
@@ -1060,7 +1080,7 @@
 
 .comms-title {
   font-family: var(--font-serif);
-  font-size: 17px;
+  font-size: 16px;
   letter-spacing: 0.6px;
   margin-top: 2px;
   color: #f3ead4;
@@ -1073,7 +1093,7 @@
 
 /* ===== Chat ===== */
 .chat-container {
-  height: min(360px, 42vh);
+  height: min(320px, 38vh);
   display: flex;
   flex-direction: column;
 }
@@ -1081,7 +1101,7 @@
 .chat-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 12px 10px;
+  padding: 10px 10px 8px;
   scrollbar-width: thin;
   scrollbar-color: rgba(240, 192, 64, 0.6) transparent;
 }
@@ -1182,7 +1202,7 @@
 .chat-input-area {
   display: flex;
   gap: 8px;
-  padding: 10px;
+  padding: 9px;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.26));
   transition: transform 0.22s ease, box-shadow 0.22s ease;
@@ -1240,7 +1260,7 @@
 
 /* ===== Game Log ===== */
 .game-log-panel {
-  height: min(190px, 24vh);
+  height: min(160px, 20vh);
   display: flex;
   flex-direction: column;
 }
@@ -1248,7 +1268,7 @@
 .game-log {
   flex: 1;
   overflow-y: auto;
-  padding: 10px 12px 12px;
+  padding: 9px 10px 10px;
   font-size: 12px;
   color: var(--text-primary);
   scrollbar-width: thin;
@@ -1353,65 +1373,187 @@
   text-shadow: 0 0 12px var(--gold-glow);
 }
 
-/* Responsive layout for comms */
-@media (max-width: 1200px) {
-  .comms-dock {
-    right: 14px;
-    bottom: 120px;
-    width: min(330px, calc(100vw - 24px));
+/* Responsive layout for table + comms */
+@media (max-width: 1680px) {
+  #game-view {
+    --comms-dock-width: clamp(250px, 20vw, 300px);
+    --table-side-padding: calc(var(--comms-dock-width) + 28px);
+  }
+
+  .poker-table {
+    width: min(90vw, calc(100vw - var(--table-side-padding) - 20px), 790px);
+    height: min(53vh, 400px);
   }
 }
 
-@media (max-width: 960px) {
+@media (max-width: 1280px) {
+  #game-view {
+    --comms-dock-width: 270px;
+    --comms-dock-bottom: 118px;
+    --table-side-padding: 292px;
+  }
+
+  .poker-table {
+    width: min(88vw, calc(100vw - var(--table-side-padding) - 18px), 740px);
+    height: min(49vh, 370px);
+  }
+
+  .player-info {
+    min-width: 98px;
+    padding: 8px 12px;
+  }
+
+  .player-name {
+    font-size: 13px;
+    max-width: 106px;
+  }
+
+  .player-chips {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 1100px) {
+  #game-view {
+    --table-side-padding: 16px;
+    --comms-dock-width: min(520px, calc(100vw - 20px));
+    --comms-dock-bottom: 110px;
+  }
+
+  .table-area {
+    padding: 8px 12px 148px;
+  }
+
   .comms-dock {
-    width: min(300px, calc(100vw - 20px));
-    bottom: 118px;
+    left: 10px;
+    right: 10px;
+    width: auto;
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 8px;
   }
 
   .chat-container {
-    height: min(320px, 38vh);
+    min-width: 0;
+    height: min(220px, 30vh);
+  }
+
+  .game-log-panel {
+    min-width: 0;
+    height: min(156px, 20vh);
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 920px), (max-height: 820px) {
+  #game-view {
+    --table-side-padding: 14px;
+    --comms-dock-bottom: 104px;
+  }
+
+  .table-area {
+    padding: 8px 10px 134px;
+  }
+
+  .poker-table {
+    width: min(94vw, 640px);
+    height: min(43vh, 320px);
+    border-width: 4px;
+    outline-width: 3px;
+  }
+
   .comms-dock {
-    left: 12px;
-    right: 12px;
+    left: 10px;
+    right: 10px;
     width: auto;
-    bottom: 122px;
-    display: grid;
-    grid-template-columns: 1.5fr 1fr;
-    gap: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
   }
 
-  .chat-container,
+  .comms-dock.is-compact .comms-toggle {
+    display: flex;
+  }
+
+  .comms-dock.is-collapsed .chat-container,
+  .comms-dock.is-collapsed .game-log-panel {
+    display: none;
+  }
+
+  .comms-dock.is-collapsed {
+    left: auto;
+    right: 10px;
+    width: min(220px, calc(100vw - 20px));
+  }
+
+  .chat-container {
+    height: min(190px, 27vh);
+  }
+
   .game-log-panel {
-    min-width: 0;
-    height: min(220px, 32vh);
-  }
-
-  .chat-messages {
-    padding: 10px;
+    height: min(120px, 16vh);
   }
 
   .chat-text {
     font-size: 12.5px;
   }
+
+  .bottom-controls {
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .action-bar {
+    gap: 8px;
+    padding: 10px 12px;
+  }
+
+  .my-hand-area .card {
+    width: 68px;
+    height: 95px;
+  }
 }
 
-@media (max-width: 560px) {
-  .comms-dock {
-    grid-template-columns: 1fr;
-    gap: 8px;
-    bottom: 114px;
+@media (max-width: 640px) {
+  #game-view {
+    --comms-dock-bottom: 98px;
   }
 
-  .chat-container {
-    height: min(180px, 29vh);
+  .table-area {
+    padding: 8px 8px 126px;
   }
 
-  .game-log-panel {
-    height: min(112px, 17vh);
+  .poker-table {
+    width: min(95vw, 520px);
+    height: min(38vh, 270px);
+  }
+
+  .player-info {
+    min-width: 82px;
+    padding: 6px 8px;
+  }
+
+  .player-name {
+    font-size: 12px;
+    max-width: 88px;
+  }
+
+  .player-chips {
+    font-size: 12px;
+  }
+
+  .player-total-bet-display {
+    font-size: 10px;
+    padding: 2px 5px;
+  }
+
+  .comms-dock.is-collapsed {
+    right: 8px;
+    width: min(200px, calc(100vw - 16px));
+  }
+
+  .comms-toggle {
+    padding: 7px 10px;
+    font-size: 11px;
   }
 
   .comms-header {
@@ -1422,19 +1564,32 @@
     font-size: 15px;
   }
 
+  .chat-container {
+    height: min(162px, 24vh);
+  }
+
+  .game-log-panel {
+    height: min(94px, 14vh);
+  }
+
   .chat-input-area {
-    padding: 8px;
+    padding: 7px;
     gap: 6px;
   }
 
   .chat-input {
-    padding: 8px 10px;
+    padding: 7px 9px;
     font-size: 12px;
   }
 
   .btn-send-chat {
-    min-width: 56px;
-    padding: 8px 10px;
-    font-size: 12px;
+    min-width: 52px;
+    padding: 7px 9px;
+    font-size: 11px;
+  }
+
+  .my-hand-area .card {
+    width: 60px;
+    height: 84px;
   }
 }

--- a/public/css/game.css
+++ b/public/css/game.css
@@ -994,29 +994,269 @@
   }
 }
 
-/* ===== Game Log ===== */
-.game-log {
+/* ===== Game View ===== */
+#game-view {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+/* ===== Comms Dock ===== */
+.comms-dock {
   position: absolute;
-  bottom: 300px;
-  left: 12px;
-  width: 220px;
-  max-height: 150px;
-  overflow-y: auto;
-  background: rgba(5, 7, 12, 0.6);
-  border-radius: 10px;
-  padding: 10px;
-  color: var(--text-primary);
-  font-size: 12px;
-  z-index: 110;
+  right: 20px;
+  bottom: 124px;
+  width: min(360px, calc(100vw - 32px));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 125;
+  pointer-events: none;
+}
+
+.comms-dock > * {
   pointer-events: auto;
-  backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.chat-container,
+.game-log-panel {
+  border-radius: 16px;
+  border: 1px solid rgba(240, 192, 64, 0.22);
+  background: linear-gradient(165deg, rgba(14, 21, 33, 0.92) 0%, rgba(7, 11, 19, 0.96) 100%);
+  box-shadow:
+    0 16px 38px rgba(0, 0, 0, 0.48),
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(14px);
+  overflow: hidden;
+  position: relative;
+}
+
+.chat-container::before,
+.game-log-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(120px 40px at top right, rgba(240, 192, 64, 0.11) 0%, transparent 70%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 24%);
+}
+
+.comms-header {
+  padding: 10px 14px 9px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(240, 192, 64, 0.14), rgba(240, 192, 64, 0.02));
+}
+
+.comms-kicker {
+  font-size: 10px;
+  letter-spacing: 1.8px;
+  color: rgba(240, 192, 64, 0.85);
+  font-weight: 700;
+}
+
+.comms-title {
+  font-family: var(--font-serif);
+  font-size: 17px;
+  letter-spacing: 0.6px;
+  margin-top: 2px;
+  color: #f3ead4;
+  text-shadow: 0 0 14px rgba(240, 192, 64, 0.22);
+}
+
+.comms-header-log {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(240, 192, 64, 0.01));
+}
+
+/* ===== Chat ===== */
+.chat-container {
+  height: min(360px, 42vh);
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 12px 10px;
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+  scrollbar-color: rgba(240, 192, 64, 0.6) transparent;
+}
+
+.chat-messages::-webkit-scrollbar {
+  width: 5px;
+}
+
+.chat-messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-messages::-webkit-scrollbar-thumb {
+  background-color: rgba(240, 192, 64, 0.45);
+  border-radius: 4px;
+}
+
+.chat-message {
+  display: flex;
+  margin-bottom: 10px;
+  animation: chatMessageEnter 0.33s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.chat-message:last-child {
+  margin-bottom: 0;
+}
+
+.chat-message.is-me {
+  justify-content: flex-end;
+}
+
+.chat-bubble {
+  width: fit-content;
+  max-width: 100%;
+  border-radius: 12px;
+  padding: 9px 11px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
+  box-shadow:
+    0 8px 20px rgba(0, 0, 0, 0.38),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.chat-message.chat-ai .chat-bubble {
+  border-color: rgba(233, 69, 96, 0.46);
+  background: linear-gradient(150deg, rgba(233, 69, 96, 0.2), rgba(233, 69, 96, 0.06));
+  box-shadow:
+    0 8px 22px rgba(233, 69, 96, 0.2),
+    0 2px 10px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.chat-message.is-me .chat-bubble {
+  border-color: rgba(66, 135, 245, 0.45);
+  background: linear-gradient(150deg, rgba(66, 135, 245, 0.24), rgba(66, 135, 245, 0.08));
+  box-shadow:
+    0 8px 22px rgba(66, 135, 245, 0.2),
+    0 2px 10px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.chat-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 4px;
+}
+
+.chat-name {
+  color: var(--gold);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.4px;
+}
+
+.chat-name.ai {
+  color: #ff7b95;
+}
+
+.chat-time {
+  color: rgba(232, 230, 225, 0.56);
+  font-size: 11px;
+  letter-spacing: 0.2px;
+}
+
+.chat-message.is-me .chat-name {
+  color: #9ec6ff;
+}
+
+.chat-text {
+  color: #ede8de;
+  font-size: 13px;
+  line-height: 1.45;
+  letter-spacing: 0.15px;
+  word-break: break-word;
+}
+
+.chat-input-area {
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.26));
+  transition: transform 0.22s ease, box-shadow 0.22s ease;
+}
+
+.chat-input-area:focus-within {
+  animation: chatInputFocus 0.26s ease-out forwards;
+}
+
+.chat-input {
+  flex: 1;
+  padding: 9px 12px;
+  border-radius: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+}
+
+.chat-input:focus {
+  border-color: rgba(240, 192, 64, 0.78);
+  box-shadow: 0 0 0 2px rgba(240, 192, 64, 0.2), 0 0 18px rgba(240, 192, 64, 0.15);
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.chat-input::placeholder {
+  color: rgba(232, 230, 225, 0.45);
+}
+
+.btn-send-chat {
+  padding: 8px 14px;
+  border-radius: 9px;
+  border: 1px solid rgba(240, 192, 64, 0.36);
+  background: linear-gradient(140deg, #f0c040 0%, #d5a438 100%);
+  color: #1e1710;
+  font-weight: 800;
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  min-width: 64px;
+  transition: transform 0.14s, filter 0.18s, box-shadow 0.18s;
+  box-shadow: 0 8px 16px rgba(240, 192, 64, 0.22);
+}
+
+.btn-send-chat:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(240, 192, 64, 0.28);
+}
+
+.btn-send-chat:active {
+  transform: translateY(0);
+}
+
+/* ===== Game Log ===== */
+.game-log-panel {
+  height: min(190px, 24vh);
+  display: flex;
+  flex-direction: column;
+}
+
+.game-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 12px 12px;
+  font-size: 12px;
+  color: var(--text-primary);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(240, 192, 64, 0.4) transparent;
 }
 
 .game-log::-webkit-scrollbar {
-  width: 3px;
+  width: 4px;
 }
 
 .game-log::-webkit-scrollbar-track {
@@ -1024,15 +1264,16 @@
 }
 
 .game-log::-webkit-scrollbar-thumb {
-  background-color: rgba(255, 255, 255, 0.15);
-  border-radius: 3px;
+  background-color: rgba(240, 192, 64, 0.35);
+  border-radius: 4px;
 }
 
 .log-entry {
-  margin-bottom: 5px;
+  margin-bottom: 6px;
   line-height: 1.4;
-  word-wrap: break-word;
-  opacity: 0.8;
+  word-break: break-word;
+  opacity: 0.78;
+  animation: logEntryEnter 0.25s ease-out;
 }
 
 .log-entry:last-child {
@@ -1046,7 +1287,40 @@
 }
 
 .log-action {
-  color: var(--text-secondary);
+  color: #c9c6bc;
+}
+
+@keyframes chatMessageEnter {
+  from {
+    transform: translateY(6px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes chatInputFocus {
+  from {
+    box-shadow: inset 0 0 0 0 rgba(240, 192, 64, 0.1);
+    transform: translateY(0);
+  }
+  to {
+    box-shadow:
+      inset 0 0 0 1px rgba(240, 192, 64, 0.24),
+      0 -8px 20px rgba(240, 192, 64, 0.08);
+    transform: translateY(-1px);
+  }
+}
+
+@keyframes logEntryEnter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.78;
+  }
 }
 
 /* ===== Card Deal Animation ===== */
@@ -1079,118 +1353,88 @@
   text-shadow: 0 0 12px var(--gold-glow);
 }
 
-/* ===== Chat ===== */
-.chat-container {
-  flex: 0 0 300px;
-  height: 280px;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  border-radius: 12px;
-  background: var(--bg-glass);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  backdrop-filter: blur(8px);
-  max-width: 300px;
+/* Responsive layout for comms */
+@media (max-width: 1200px) {
+  .comms-dock {
+    right: 14px;
+    bottom: 120px;
+    width: min(330px, calc(100vw - 24px));
+  }
 }
 
-.chat-messages {
-  flex: 1;
-  overflow-y: auto;
-  padding: 12px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--gold) var(--bg-glass);
-}
+@media (max-width: 960px) {
+  .comms-dock {
+    width: min(300px, calc(100vw - 20px));
+    bottom: 118px;
+  }
 
-.chat-messages::-webkit-scrollbar {
-  width: 6px;
-}
-
-.chat-messages::-webkit-scrollbar-track {
-  background: var(--bg-glass);
-}
-
-.chat-messages::-webkit-scrollbar-thumb {
-  background: var(--gold);
-  border-radius: 3px;
-}
-
-.chat-message {
-  margin-bottom: 8px;
-  line-height: 1.4;
-  word-wrap: break-word;
-  font-size: 13px;
-}
-
-.chat-message.chat-ai {
-  opacity: 0.9;
-}
-
-.chat-name {
-  color: var(--gold);
-  font-weight: 600;
-  margin-right: 6px;
-}
-
-.chat-name.ai {
-  color: #e94560;
-}
-
-.chat-text {
-  color: var(--text-primary);
-}
-
-.chat-input-area {
-  display: flex;
-  gap: 8px;
-  padding: 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(0, 0, 0, 0.1);
-}
-
-.chat-input {
-  flex: 1;
-  padding: 8px 12px;
-  background: var(--bg-glass);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 6px;
-  color: var(--text-primary);
-  font-size: 13px;
-  outline: none;
-}
-
-.chat-input:focus {
-  border-color: var(--gold);
-  box-shadow: 0 0 8px rgba(240, 192, 64, 0.2);
-}
-
-.chat-input::placeholder {
-  color: var(--text-secondary);
-}
-
-.btn-send-chat {
-  padding: 8px 16px;
-  background: var(--gold);
-  border: none;
-  border-radius: 6px;
-  color: #1a1a1a;
-  font-weight: 600;
-  font-size: 13px;
-  cursor: pointer;
-  transition: transform 0.15s, box-shadow 0.15s;
-}
-
-.btn-send-chat:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(240, 192, 64, 0.3);
-}
-
-.btn-send-chat:active {
-  transform: translateY(0);
-}
-
-/* Responsive layout for chat */
-@media (max-width: 768px) {
   .chat-container {
-    display: none;
+    height: min(320px, 38vh);
+  }
+}
+
+@media (max-width: 768px) {
+  .comms-dock {
+    left: 12px;
+    right: 12px;
+    width: auto;
+    bottom: 122px;
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    gap: 10px;
+  }
+
+  .chat-container,
+  .game-log-panel {
+    min-width: 0;
+    height: min(220px, 32vh);
+  }
+
+  .chat-messages {
+    padding: 10px;
+  }
+
+  .chat-text {
+    font-size: 12.5px;
+  }
+}
+
+@media (max-width: 560px) {
+  .comms-dock {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    bottom: 114px;
+  }
+
+  .chat-container {
+    height: min(180px, 29vh);
+  }
+
+  .game-log-panel {
+    height: min(112px, 17vh);
+  }
+
+  .comms-header {
+    padding: 8px 10px 7px;
+  }
+
+  .comms-title {
+    font-size: 15px;
+  }
+
+  .chat-input-area {
+    padding: 8px;
+    gap: 6px;
+  }
+
+  .chat-input {
+    padding: 8px 10px;
+    font-size: 12px;
+  }
+
+  .btn-send-chat {
+    min-width: 56px;
+    padding: 8px 10px;
+    font-size: 12px;
   }
 }

--- a/public/game.html
+++ b/public/game.html
@@ -62,6 +62,14 @@
       </div>
 
       <aside class="comms-dock" id="comms-dock">
+        <button
+          class="comms-toggle"
+          id="comms-toggle"
+          type="button"
+          aria-expanded="true"
+          aria-controls="chat-container game-log-panel">
+          收起面板
+        </button>
         <section class="chat-container" id="chat-container">
           <header class="comms-header">
             <div class="comms-kicker">TABLE TALK</div>
@@ -74,7 +82,7 @@
           </div>
         </section>
 
-        <section class="game-log-panel">
+        <section class="game-log-panel" id="game-log-panel">
           <header class="comms-header comms-header-log">
             <div class="comms-kicker">GAME LOG</div>
             <h3 class="comms-title">牌局记录</h3>

--- a/public/game.html
+++ b/public/game.html
@@ -44,14 +44,6 @@
         </div>
         <div class="timer-text" id="timer-text"></div>
 
-        <div class="chat-container" id="chat-container">
-          <div class="chat-messages" id="chat-messages"></div>
-          <div class="chat-input-area">
-            <input type="text" id="chat-input" class="chat-input" placeholder="输入消息..." maxlength="100">
-            <button class="btn-send-chat" id="btn-send-chat">发送</button>
-          </div>
-        </div>
-
         <div class="action-bar hidden" id="action-bar">
           <button class="btn-fold" id="btn-fold">弃牌</button>
           <button class="btn-check hidden" id="btn-check">过牌</button>
@@ -69,7 +61,27 @@
         </div>
       </div>
 
-      <div class="game-log" id="game-log"></div>
+      <aside class="comms-dock" id="comms-dock">
+        <section class="chat-container" id="chat-container">
+          <header class="comms-header">
+            <div class="comms-kicker">TABLE TALK</div>
+            <h3 class="comms-title">高桌私语</h3>
+          </header>
+          <div class="chat-messages" id="chat-messages"></div>
+          <div class="chat-input-area">
+            <input type="text" id="chat-input" class="chat-input" placeholder="输入消息..." maxlength="100">
+            <button class="btn-send-chat" id="btn-send-chat">发送</button>
+          </div>
+        </section>
+
+        <section class="game-log-panel">
+          <header class="comms-header comms-header-log">
+            <div class="comms-kicker">GAME LOG</div>
+            <h3 class="comms-title">牌局记录</h3>
+          </header>
+          <div class="game-log" id="game-log"></div>
+        </section>
+      </aside>
     </div>
 
     <!-- Showdown Overlay -->

--- a/public/game.html
+++ b/public/game.html
@@ -38,38 +38,38 @@
       </div>
 
       <div class="bottom-controls">
-        <div class="my-hand-area" id="my-hand"></div>
-        <div class="timer-bar" id="timer-bar">
-          <div class="timer-bar-fill" id="timer-fill"></div>
-        </div>
-        <div class="timer-text" id="timer-text"></div>
+        <div class="action-center">
+          <div class="my-hand-area" id="my-hand"></div>
 
-        <div class="action-bar hidden" id="action-bar">
-          <button class="btn-fold" id="btn-fold">弃牌</button>
-          <button class="btn-check hidden" id="btn-check">过牌</button>
-          <button class="btn-call hidden" id="btn-call">跟注</button>
-
-          <div id="raise-controls" class="raise-controls hidden">
-            <span class="raise-amount" id="raise-amount">0</span>
-            <input type="range" id="raise-slider" min="0" max="0" value="0">
-            <input type="number" id="raise-input" class="raise-input" value="0">
-            <button class="btn-raise hidden" id="btn-raise">加注</button>
+          <div class="timer-cluster">
+            <div class="timer-bar" id="timer-bar">
+              <div class="timer-bar-fill" id="timer-fill"></div>
+            </div>
+            <div class="timer-text" id="timer-text"></div>
           </div>
 
-          <button class="btn-allin hidden" id="btn-allin">全下</button>
-          <button class="btn-pause hidden" id="btn-pause">暂停</button>
+          <div class="action-bar hidden" id="action-bar">
+            <div class="action-row action-row-main">
+              <button class="btn-fold" id="btn-fold">弃牌</button>
+              <button class="btn-check hidden" id="btn-check">过牌</button>
+              <button class="btn-call hidden" id="btn-call">跟注</button>
+              <button class="btn-allin hidden" id="btn-allin">全下</button>
+              <button class="btn-pause hidden" id="btn-pause">暂停</button>
+            </div>
+
+            <div class="action-row action-row-raise">
+              <div id="raise-controls" class="raise-controls hidden">
+                <span class="raise-amount" id="raise-amount">0</span>
+                <input type="range" id="raise-slider" min="0" max="0" value="0">
+                <input type="number" id="raise-input" class="raise-input" value="0">
+                <button class="btn-raise hidden" id="btn-raise">加注</button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
       <aside class="comms-dock" id="comms-dock">
-        <button
-          class="comms-toggle"
-          id="comms-toggle"
-          type="button"
-          aria-expanded="true"
-          aria-controls="chat-container game-log-panel">
-          收起面板
-        </button>
         <section class="chat-container" id="chat-container">
           <header class="comms-header">
             <div class="comms-kicker">TABLE TALK</div>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -62,6 +62,8 @@
   const btnCloseShowdown = document.getElementById('btn-close-showdown');
 
   // Chat elements
+  const commsDock = document.getElementById('comms-dock');
+  const btnToggleComms = document.getElementById('comms-toggle');
   const chatContainer = document.getElementById('chat-container');
   const chatMessages = document.getElementById('chat-messages');
   const chatInput = document.getElementById('chat-input');
@@ -84,6 +86,7 @@
   let autoStartInterval = null;
   let isGameStarted = false;
   let isGamePaused = false;
+  let commsManualCollapsed = null;
 
   /**
    * Helper function to bind button actions with common pattern.
@@ -102,6 +105,37 @@
         onSuccess(res);
       }
     });
+  }
+
+  function isCompactCommsViewport() {
+    return window.matchMedia('(max-width: 920px)').matches ||
+      window.matchMedia('(max-height: 820px)').matches;
+  }
+
+  function setCommsCollapsed(collapsed) {
+    if (!commsDock || !btnToggleComms) return;
+    commsDock.classList.toggle('is-collapsed', collapsed);
+    btnToggleComms.textContent = collapsed ? '展开面板' : '收起面板';
+    btnToggleComms.setAttribute('aria-expanded', String(!collapsed));
+  }
+
+  function syncCommsLayout() {
+    if (!commsDock || !btnToggleComms) return;
+    const compact = isCompactCommsViewport();
+    commsDock.classList.toggle('is-compact', compact);
+
+    if (!compact) {
+      commsManualCollapsed = null;
+      setCommsCollapsed(false);
+      return;
+    }
+
+    if (commsManualCollapsed === null) {
+      setCommsCollapsed(true);
+      return;
+    }
+
+    setCommsCollapsed(commsManualCollapsed);
   }
 
   // --- Waiting Room ---
@@ -608,6 +642,25 @@
       sendChatMessage();
     }
   });
+
+  if (btnToggleComms && commsDock) {
+    btnToggleComms.addEventListener('click', () => {
+      const nextCollapsed = !commsDock.classList.contains('is-collapsed');
+      commsManualCollapsed = nextCollapsed;
+      setCommsCollapsed(nextCollapsed);
+    });
+  }
+
+  chatInput.addEventListener('focus', () => {
+    if (!commsDock || !commsDock.classList.contains('is-compact')) return;
+    if (!commsDock.classList.contains('is-collapsed')) return;
+    commsManualCollapsed = false;
+    setCommsCollapsed(false);
+  });
+
+  window.addEventListener('resize', syncCommsLayout);
+  window.addEventListener('orientationchange', syncCommsLayout);
+  syncCommsLayout();
 
   // --- Timer ---
 

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -523,16 +523,63 @@
     addChatMessage(data);
   });
 
+  function formatChatTime(timestamp) {
+    const date = new Date(typeof timestamp === 'number' ? timestamp : Date.now());
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleTimeString('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
   function addChatMessage(data) {
-    const { playerName, message, isAI } = data;
+    const { playerId, playerName, message, isAI, timestamp } = data;
+    if (!message) return;
+
+    const isMe = playerId === myId();
     const entry = document.createElement('div');
     entry.className = 'chat-message';
+    if (isMe) {
+      entry.classList.add('is-me');
+    }
     if (isAI) {
       entry.classList.add('chat-ai');
     }
-    entry.innerHTML = `<span class="chat-name ${isAI ? 'ai' : ''}">${playerName}</span><span class="chat-text">${message}</span>`;
+
+    const bubble = document.createElement('div');
+    bubble.className = 'chat-bubble';
+
+    const meta = document.createElement('div');
+    meta.className = 'chat-meta';
+
+    const nameEl = document.createElement('span');
+    nameEl.className = `chat-name ${isAI ? 'ai' : ''}`.trim();
+    nameEl.textContent = playerName || '未知玩家';
+
+    const timeEl = document.createElement('span');
+    timeEl.className = 'chat-time';
+    timeEl.textContent = formatChatTime(timestamp);
+
+    const textEl = document.createElement('div');
+    textEl.className = 'chat-text';
+    textEl.textContent = message;
+
+    meta.appendChild(nameEl);
+    meta.appendChild(timeEl);
+    bubble.appendChild(meta);
+    bubble.appendChild(textEl);
+    entry.appendChild(bubble);
+
     chatMessages.appendChild(entry);
-    chatMessages.scrollTop = chatMessages.scrollHeight;
+
+    if (typeof chatMessages.scrollTo === 'function') {
+      chatMessages.scrollTo({
+        top: chatMessages.scrollHeight,
+        behavior: 'smooth'
+      });
+    } else {
+      chatMessages.scrollTop = chatMessages.scrollHeight;
+    }
 
     // Keep max 50 messages
     while (chatMessages.children.length > 50) {
@@ -555,7 +602,7 @@
 
   btnSendChat.addEventListener('click', sendChatMessage);
 
-  chatInput.addEventListener('keypress', (e) => {
+  chatInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       sendChatMessage();

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -62,9 +62,6 @@
   const btnCloseShowdown = document.getElementById('btn-close-showdown');
 
   // Chat elements
-  const commsDock = document.getElementById('comms-dock');
-  const btnToggleComms = document.getElementById('comms-toggle');
-  const chatContainer = document.getElementById('chat-container');
   const chatMessages = document.getElementById('chat-messages');
   const chatInput = document.getElementById('chat-input');
   const btnSendChat = document.getElementById('btn-send-chat');
@@ -86,7 +83,6 @@
   let autoStartInterval = null;
   let isGameStarted = false;
   let isGamePaused = false;
-  let commsManualCollapsed = null;
 
   /**
    * Helper function to bind button actions with common pattern.
@@ -105,37 +101,6 @@
         onSuccess(res);
       }
     });
-  }
-
-  function isCompactCommsViewport() {
-    return window.matchMedia('(max-width: 920px)').matches ||
-      window.matchMedia('(max-height: 820px)').matches;
-  }
-
-  function setCommsCollapsed(collapsed) {
-    if (!commsDock || !btnToggleComms) return;
-    commsDock.classList.toggle('is-collapsed', collapsed);
-    btnToggleComms.textContent = collapsed ? '展开面板' : '收起面板';
-    btnToggleComms.setAttribute('aria-expanded', String(!collapsed));
-  }
-
-  function syncCommsLayout() {
-    if (!commsDock || !btnToggleComms) return;
-    const compact = isCompactCommsViewport();
-    commsDock.classList.toggle('is-compact', compact);
-
-    if (!compact) {
-      commsManualCollapsed = null;
-      setCommsCollapsed(false);
-      return;
-    }
-
-    if (commsManualCollapsed === null) {
-      setCommsCollapsed(true);
-      return;
-    }
-
-    setCommsCollapsed(commsManualCollapsed);
   }
 
   // --- Waiting Room ---
@@ -642,25 +607,6 @@
       sendChatMessage();
     }
   });
-
-  if (btnToggleComms && commsDock) {
-    btnToggleComms.addEventListener('click', () => {
-      const nextCollapsed = !commsDock.classList.contains('is-collapsed');
-      commsManualCollapsed = nextCollapsed;
-      setCommsCollapsed(nextCollapsed);
-    });
-  }
-
-  chatInput.addEventListener('focus', () => {
-    if (!commsDock || !commsDock.classList.contains('is-compact')) return;
-    if (!commsDock.classList.contains('is-collapsed')) return;
-    commsManualCollapsed = false;
-    setCommsCollapsed(false);
-  });
-
-  window.addEventListener('resize', syncCommsLayout);
-  window.addEventListener('orientationchange', syncCommsLayout);
-  syncCommsLayout();
 
   // --- Timer ---
 


### PR DESCRIPTION
## 功能概述
重新设计了聊天框 UI，解决了小屏遮挡问题，提升了用户体验。

## 主要改动

### 1. 聊天框 UI 优化
- LUXURY NOIR 主题设计（黑金渐变 + 精美阴影）
- 消息气泡带动画效果（淡入上浮）
- AI/自己/他人消息差异化样式
- 时间戳显示

### 2. 响应式布局
- **大屏（≥980px）**：中间牌桌 + 右侧聊天
- **中屏（≤980px）**：左侧牌桌+操作 + 右侧窄聊天
- **小屏（≤680px）**：超窄聊天列，自适应宽度

### 3. 手牌和操作按钮重新设计
- 手牌从左下角移到底部中央
- 操作按钮围绕手牌集中布局
- 形成统一的操作中心

### 4. 小屏优化
- 修复手牌/操作按钮与牌桌重叠问题
- 调整 z-index 层级
- 聊天框不遮挡核心游戏区域

## 技术改进
- CSS Grid 布局架构
- 移除展开/折叠交互，简化用户体验
- 优化响应式断点

## 测试
已在 2560×1440 和 1512×982 分辨率下测试通过。